### PR TITLE
feat: add basic settings panel

### DIFF
--- a/extension/newtab.html
+++ b/extension/newtab.html
@@ -7,6 +7,35 @@
 </head>
 <body>
   <div id="clock" class="widget clock-widget"></div>
+  <div id="settings-button">&#9881;</div>
+  <div id="settings-panel" class="hidden">
+    <section>
+      <h2>Export / Import</h2>
+      <div class="export-import">
+        <select id="export-type">
+          <option value="text">Text</option>
+          <option value="file">File</option>
+        </select>
+        <button id="export-btn">Export</button>
+      </div>
+      <div class="export-import">
+        <select id="import-type">
+          <option value="text">Text</option>
+          <option value="file">File</option>
+        </select>
+        <button id="import-btn">Import</button>
+        <input type="file" id="import-file" accept="application/json" style="display:none">
+      </div>
+    </section>
+    <section>
+      <h2>Background</h2>
+      <div class="background-settings">
+        <input type="color" id="bg-color-picker">
+        <input type="file" id="bg-image-picker" accept="image/*">
+      </div>
+    </section>
+  </div>
   <script src="clock.js"></script>
+  <script src="settings.js"></script>
 </body>
 </html>

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -1,0 +1,114 @@
+const settingsButton = document.getElementById('settings-button');
+const settingsPanel = document.getElementById('settings-panel');
+
+settingsButton.addEventListener('click', () => {
+  settingsPanel.classList.toggle('hidden');
+});
+
+const defaultSettings = {
+  background: { type: 'color', value: '#222' }
+};
+
+function loadSettings() {
+  try {
+    return JSON.parse(localStorage.getItem('settings')) || defaultSettings;
+  } catch (e) {
+    return defaultSettings;
+  }
+}
+
+function saveSettings(s) {
+  localStorage.setItem('settings', JSON.stringify(s));
+}
+
+function applyBackground(s) {
+  if (s.background.type === 'color') {
+    document.body.style.background = s.background.value;
+  } else if (s.background.type === 'image') {
+    document.body.style.background = `url(${s.background.value}) center/cover no-repeat`;
+  }
+}
+
+let settings = loadSettings();
+applyBackground(settings);
+
+// background controls
+const colorPicker = document.getElementById('bg-color-picker');
+const imagePicker = document.getElementById('bg-image-picker');
+
+if (settings.background.type === 'color') {
+  colorPicker.value = settings.background.value;
+}
+
+colorPicker.addEventListener('input', (e) => {
+  settings.background = { type: 'color', value: e.target.value };
+  applyBackground(settings);
+  saveSettings(settings);
+});
+
+imagePicker.addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    settings.background = { type: 'image', value: reader.result };
+    applyBackground(settings);
+    saveSettings(settings);
+  };
+  reader.readAsDataURL(file);
+});
+
+// export / import
+const exportBtn = document.getElementById('export-btn');
+const exportType = document.getElementById('export-type');
+const importBtn = document.getElementById('import-btn');
+const importType = document.getElementById('import-type');
+const importFile = document.getElementById('import-file');
+
+exportBtn.addEventListener('click', () => {
+  const data = JSON.stringify(settings);
+  if (exportType.value === 'text') {
+    prompt('Copy your settings JSON:', data);
+  } else {
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'settings.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+});
+
+importBtn.addEventListener('click', () => {
+  if (importType.value === 'text') {
+    const data = prompt('Paste settings JSON:');
+    if (!data) return;
+    try {
+      settings = JSON.parse(data);
+      saveSettings(settings);
+      applyBackground(settings);
+    } catch {
+      alert('Invalid JSON');
+    }
+  } else {
+    importFile.click();
+  }
+});
+
+importFile.addEventListener('change', () => {
+  const file = importFile.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      settings = JSON.parse(reader.result);
+      saveSettings(settings);
+      applyBackground(settings);
+    } catch {
+      alert('Invalid JSON file');
+    }
+  };
+  reader.readAsText(file);
+});
+

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -12,3 +12,34 @@ body {
 .clock-widget {
   font-size: 4rem;
 }
+
+#settings-button {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+#settings-panel {
+  position: fixed;
+  bottom: 50px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.8);
+  padding: 10px;
+  border-radius: 4px;
+  color: #eee;
+}
+
+.hidden {
+  display: none;
+}
+
+.export-import {
+  margin-bottom: 0.5rem;
+}
+
+.background-settings input {
+  display: block;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add bottom-right gear to open settings panel
- allow export/import of settings via text or file
- support changing background color or image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895fc6427108331a917bfb4f3f9201a