### PR TITLE
Refactor settings into tabs with appearance controls

### DIFF
--- a/extension/newtab.html
+++ b/extension/newtab.html
@@ -9,7 +9,11 @@
   <div id="clock" class="widget clock-widget"></div>
   <div id="settings-button">&#9881;</div>
   <div id="settings-panel" class="hidden">
-    <section>
+    <div class="settings-tabs">
+      <button data-tab="config" class="active">Config</button>
+      <button data-tab="appearance">Appearance</button>
+    </div>
+    <div id="config-tab" class="tab-content">
       <h2>Export / Import</h2>
       <div class="export-import">
         <select id="export-type">
@@ -26,14 +30,17 @@
         <button id="import-btn">Import</button>
         <input type="file" id="import-file" accept="application/json" style="display:none">
       </div>
-    </section>
-    <section>
+    </div>
+    <div id="appearance-tab" class="tab-content hidden">
       <h2>Background</h2>
       <div class="background-settings">
         <input type="color" id="bg-color-picker">
-        <input type="file" id="bg-image-picker" accept="image/*">
+        <div class="image-wrapper">
+          <input type="file" id="bg-image-picker" accept="image/*">
+          <button id="remove-bg-image" class="remove-image hidden">&times;</button>
+        </div>
       </div>
-    </section>
+    </div>
   </div>
   <script src="clock.js"></script>
   <script src="settings.js"></script>

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -5,8 +5,21 @@ settingsButton.addEventListener('click', () => {
   settingsPanel.classList.toggle('hidden');
 });
 
+// tab handling
+const tabButtons = document.querySelectorAll('.settings-tabs button');
+const tabContents = document.querySelectorAll('.tab-content');
+tabButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    tabButtons.forEach(b => b.classList.remove('active'));
+    tabContents.forEach(c => c.classList.add('hidden'));
+    btn.classList.add('active');
+    document.getElementById(`${btn.dataset.tab}-tab`).classList.remove('hidden');
+  });
+});
+
 const defaultSettings = {
-  background: { type: 'color', value: '#222' }
+  background: { type: 'color', value: '#222' },
+  lastColor: '#222'
 };
 
 function loadSettings() {
@@ -30,20 +43,32 @@ function applyBackground(s) {
 }
 
 let settings = loadSettings();
+if (!settings.lastColor) settings.lastColor = defaultSettings.lastColor;
 applyBackground(settings);
+
+function updateBackgroundControls() {
+  if (settings.background.type === 'image') {
+    colorPicker.value = settings.lastColor || defaultSettings.lastColor;
+    removeImageBtn.classList.remove('hidden');
+  } else {
+    colorPicker.value = settings.background.value;
+    removeImageBtn.classList.add('hidden');
+  }
+}
 
 // background controls
 const colorPicker = document.getElementById('bg-color-picker');
 const imagePicker = document.getElementById('bg-image-picker');
+const removeImageBtn = document.getElementById('remove-bg-image');
 
-if (settings.background.type === 'color') {
-  colorPicker.value = settings.background.value;
-}
+updateBackgroundControls();
 
 colorPicker.addEventListener('input', (e) => {
   settings.background = { type: 'color', value: e.target.value };
+  settings.lastColor = e.target.value;
   applyBackground(settings);
   saveSettings(settings);
+  updateBackgroundControls();
 });
 
 imagePicker.addEventListener('change', (e) => {
@@ -54,8 +79,17 @@ imagePicker.addEventListener('change', (e) => {
     settings.background = { type: 'image', value: reader.result };
     applyBackground(settings);
     saveSettings(settings);
+    updateBackgroundControls();
   };
   reader.readAsDataURL(file);
+});
+
+removeImageBtn.addEventListener('click', () => {
+  settings.background = { type: 'color', value: settings.lastColor || defaultSettings.lastColor };
+  applyBackground(settings);
+  saveSettings(settings);
+  imagePicker.value = '';
+  updateBackgroundControls();
 });
 
 // export / import
@@ -88,6 +122,7 @@ importBtn.addEventListener('click', () => {
       settings = JSON.parse(data);
       saveSettings(settings);
       applyBackground(settings);
+      updateBackgroundControls();
     } catch {
       alert('Invalid JSON');
     }
@@ -105,6 +140,7 @@ importFile.addEventListener('change', () => {
       settings = JSON.parse(reader.result);
       saveSettings(settings);
       applyBackground(settings);
+      updateBackgroundControls();
     } catch {
       alert('Invalid JSON file');
     }

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -15,31 +15,106 @@ body {
 
 #settings-button {
   position: fixed;
-  bottom: 10px;
+  top: 10px;
   right: 10px;
   font-size: 1.5rem;
+  padding: 0.4rem;
   cursor: pointer;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  backdrop-filter: blur(4px);
+  transition: background 0.3s;
+}
+
+#settings-button:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 #settings-panel {
   position: fixed;
-  bottom: 50px;
-  right: 10px;
-  background: rgba(0, 0, 0, 0.8);
-  padding: 10px;
-  border-radius: 4px;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: min(90vw, 320px);
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(10px);
   color: #eee;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
 }
 
 .hidden {
   display: none;
 }
 
+.settings-tabs {
+  display: flex;
+}
+
+.settings-tabs button {
+  flex: 1;
+  padding: 0.5rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.settings-tabs button.active,
+.settings-tabs button:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.tab-content {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
 .export-import {
   margin-bottom: 0.5rem;
 }
 
-.background-settings input {
-  display: block;
-  margin-bottom: 0.5rem;
+.background-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.image-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.remove-image {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+button {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #fff;
+  padding: 0.4rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+button:hover {
+  background: rgba(255, 255, 255, 0.2);
 }


### PR DESCRIPTION
## Summary
- Split settings into Config and Appearance tabs
- Allow removing custom background images
- Refresh settings UI with a modern glassy style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896014fbef08331bedeaaacd757ed99