### PR TITLE
Fix settings panel toggling and tab styling

### DIFF
--- a/extension/settings.js
+++ b/extension/settings.js
@@ -5,11 +5,14 @@ const closeSettingsButton = document.getElementById('close-settings');
 settingsPanel.classList.add('hidden');
 
 settingsButton.addEventListener('click', () => {
+  settingsButton.classList.add('hidden');
   settingsPanel.classList.remove('hidden');
 });
 
-closeSettingsButton.addEventListener('click', () => {
+closeSettingsButton.addEventListener('click', (e) => {
+  e.stopPropagation();
   settingsPanel.classList.add('hidden');
+  settingsButton.classList.remove('hidden');
 });
 
 // tab handling

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -15,7 +15,7 @@ body {
 
 #settings-button {
   position: fixed;
-  top: 10px;
+  bottom: 10px;
   right: 10px;
   font-size: 1.5rem;
   padding: 0.4rem;
@@ -67,16 +67,23 @@ body {
 .settings-tabs button {
   flex: 1;
   padding: 0.5rem;
-  background: transparent;
+  background: rgba(255, 255, 255, 0.1);
   border: none;
   color: inherit;
   cursor: pointer;
   transition: background 0.3s;
 }
 
-.settings-tabs button.active,
-.settings-tabs button:hover {
-  background: rgba(255, 255, 255, 0.1);
+.settings-tabs button.active {
+  background: transparent;
+}
+
+.settings-tabs button:not(.active):hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.settings-tabs button.active:hover {
+  background: transparent;
 }
 
 .tab-content {


### PR DESCRIPTION
## Summary
- prevent accidental reopening when closing settings by hiding the gear icon while the panel is open
- ensure the settings panel starts closed and move the gear icon to the bottom-right
- invert settings tab colors so the active tab matches the panel background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68960edcc1d48331a11232e41902f1dd