### PR TITLE
feat: add widget system with configurable clock

### DIFF
--- a/extension/clock.js
+++ b/extension/clock.js
@@ -1,8 +1,0 @@
-function updateClock() {
-  const now = new Date();
-  const clock = document.getElementById('clock');
-  clock.textContent = now.toLocaleTimeString();
-}
-
-setInterval(updateClock, 1000);
-updateClock();

--- a/extension/newtab.html
+++ b/extension/newtab.html
@@ -6,8 +6,9 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <div id="clock" class="widget clock-widget"></div>
+  <div id="widget-grid" class="widget-grid"></div>
   <div id="settings-button">&#9881;</div>
+  <div id="widgets-button">Widgets</div>
   <div id="settings-panel" class="hidden">
     <button id="close-settings" class="close-button">&times;</button>
     <div class="settings-tabs">
@@ -43,7 +44,12 @@
       </div>
     </div>
   </div>
-  <script src="clock.js"></script>
+  <div id="widgets-panel" class="hidden">
+    <button id="close-widgets" class="close-button">&times;</button>
+    <h2>Widgets</h2>
+    <div id="widget-list"></div>
+  </div>
   <script src="settings.js"></script>
+  <script src="widgets.js"></script>
 </body>
 </html>

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -29,7 +29,19 @@ tabButtons.forEach(btn => {
 
 const defaultSettings = {
   background: { type: 'color', value: '#222222' },
-  lastColor: '#222222'
+  lastColor: '#222222',
+  widgets: [
+    {
+      type: 'clock',
+      settings: {
+        showSeconds: true,
+        flashing: false,
+        locale: 'auto',
+        use24h: false,
+        daylightSavings: true
+      }
+    }
+  ]
 };
 
 function normalizeColor(color) {
@@ -46,6 +58,7 @@ function loadSettings() {
       s.background.value = normalizeColor(s.background.value);
     }
     s.lastColor = normalizeColor(s.lastColor || defaultSettings.lastColor);
+    s.widgets = s.widgets || defaultSettings.widgets;
     return s;
   } catch (e) {
     return { ...defaultSettings };

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -1,12 +1,28 @@
 body {
   margin: 0;
   height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   background: #222;
   color: #eee;
   font-family: sans-serif;
+}
+
+#widget-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-auto-rows: minmax(100px, auto);
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+  padding: 1rem;
+  box-sizing: border-box;
+  place-items: center;
+}
+
+.widget {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 1rem;
 }
 
 .clock-widget {
@@ -31,6 +47,24 @@ body {
   background: rgba(255, 255, 255, 0.2);
 }
 
+#widgets-button {
+  position: fixed;
+  bottom: 10px;
+  right: 60px;
+  font-size: 1.5rem;
+  padding: 0.4rem;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  backdrop-filter: blur(4px);
+  transition: background 0.3s;
+}
+
+#widgets-button:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
 #settings-panel {
   position: fixed;
   top: 0;
@@ -43,6 +77,35 @@ body {
   display: flex;
   flex-direction: column;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+#widgets-panel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(90vw, 320px);
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(10px);
+  color: #eee;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+#widgets-panel h2 {
+  margin-top: 0;
+}
+
+#widget-list button {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.widget-config-buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .hidden {

--- a/extension/widgets.js
+++ b/extension/widgets.js
@@ -1,0 +1,127 @@
+// Widget management
+const widgetGrid = document.getElementById('widget-grid');
+const widgetsButton = document.getElementById('widgets-button');
+const widgetsPanel = document.getElementById('widgets-panel');
+const closeWidgetsButton = document.getElementById('close-widgets');
+const widgetList = document.getElementById('widget-list');
+
+widgetsPanel.classList.add('hidden');
+
+widgetsButton.addEventListener('click', () => {
+  widgetsPanel.classList.remove('hidden');
+  widgetsButton.classList.add('hidden');
+});
+
+closeWidgetsButton.addEventListener('click', (e) => {
+  e.stopPropagation();
+  widgetsPanel.classList.add('hidden');
+  widgetsButton.classList.remove('hidden');
+  buildWidgetList();
+});
+
+if (!settings.widgets) settings.widgets = [];
+
+function saveAndRender() {
+  saveSettings(settings);
+  renderWidgets();
+}
+
+function renderWidgets() {
+  widgetGrid.innerHTML = '';
+  (settings.widgets || []).forEach(widget => {
+    if (widget.type === 'clock') {
+      renderClockWidget(widget);
+    }
+  });
+}
+
+function renderClockWidget(widget) {
+  const container = document.createElement('div');
+  container.className = 'widget clock-widget';
+  const span = document.createElement('span');
+  container.appendChild(span);
+  widgetGrid.appendChild(container);
+
+  function isDST(d) {
+    const jan = new Date(d.getFullYear(), 0, 1);
+    const jul = new Date(d.getFullYear(), 6, 1);
+    const stdOffset = Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+    return d.getTimezoneOffset() < stdOffset;
+  }
+
+  function update() {
+    let now = new Date();
+    if (widget.settings && widget.settings.daylightSavings === false && isDST(now)) {
+      now = new Date(now.getTime() - 3600000);
+    }
+    const locale = widget.settings && widget.settings.locale && widget.settings.locale !== 'auto'
+      ? widget.settings.locale
+      : navigator.language;
+    const opts = { hour: 'numeric', minute: 'numeric', hour12: !widget.settings.use24h };
+    if (widget.settings.showSeconds) opts.second = 'numeric';
+    let timeString = now.toLocaleTimeString(locale, opts);
+    if (widget.settings.flashing) {
+      const sep = now.getSeconds() % 2 === 0 ? ':' : ' ';
+      timeString = timeString.replace(/:/g, sep);
+    }
+    span.textContent = timeString;
+  }
+
+  update();
+  setInterval(update, 1000);
+}
+
+function addClockWidget(options) {
+  const widget = {
+    type: 'clock',
+    settings: {
+      showSeconds: options.showSeconds,
+      flashing: options.flashing,
+      locale: options.locale,
+      use24h: options.use24h,
+      daylightSavings: options.daylightSavings
+    }
+  };
+  settings.widgets.push(widget);
+  saveAndRender();
+}
+
+function openClockConfig() {
+  widgetList.innerHTML = `
+    <h3>Clock Widget</h3>
+    <label><input type="checkbox" id="clock-show-seconds" checked> Show seconds</label><br>
+    <label><input type="checkbox" id="clock-flashing"> Flashing separator</label><br>
+    <label><input type="checkbox" id="clock-use-24h"> 24 hour time</label><br>
+    <label><input type="checkbox" id="clock-daylight" checked> Use daylight savings</label><br>
+    <label>Locale: <input type="text" id="clock-locale" placeholder="auto"></label><br>
+    <div class="widget-config-buttons">
+      <button id="clock-add">Add</button>
+      <button id="clock-cancel">Cancel</button>
+    </div>
+  `;
+  document.getElementById('clock-add').addEventListener('click', () => {
+    const options = {
+      showSeconds: document.getElementById('clock-show-seconds').checked,
+      flashing: document.getElementById('clock-flashing').checked,
+      use24h: document.getElementById('clock-use-24h').checked,
+      daylightSavings: document.getElementById('clock-daylight').checked,
+      locale: document.getElementById('clock-locale').value.trim() || 'auto'
+    };
+    addClockWidget(options);
+    widgetsPanel.classList.add('hidden');
+    widgetsButton.classList.remove('hidden');
+    buildWidgetList();
+  });
+  document.getElementById('clock-cancel').addEventListener('click', buildWidgetList);
+}
+
+function buildWidgetList() {
+  widgetList.innerHTML = '';
+  const clockBtn = document.createElement('button');
+  clockBtn.textContent = 'Clock';
+  clockBtn.addEventListener('click', openClockConfig);
+  widgetList.appendChild(clockBtn);
+}
+
+buildWidgetList();
+renderWidgets();


### PR DESCRIPTION
## Summary
- introduce grid-based widget area and widgets modal
- add default clock widget with JSON-configurable options
- style and manage widgets through new widgets.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68961553e60c8331b444e7699d0a6520