### PR TITLE
Add jiggle mode with widget editing and grid layout controls

### DIFF
--- a/extension/newtab.html
+++ b/extension/newtab.html
@@ -9,6 +9,7 @@
   <div id="widget-grid" class="widget-grid"></div>
   <div id="settings-button">&#9881;</div>
   <div id="widgets-button">Widgets</div>
+  <div id="edit-button">Edit</div>
   <div id="settings-panel" class="hidden">
     <button id="close-settings" class="close-button">&times;</button>
     <div class="settings-tabs">
@@ -31,6 +32,11 @@
         </select>
         <button id="import-btn">Import</button>
         <input type="file" id="import-file" accept="application/json" style="display:none">
+      </div>
+      <h2>Layout</h2>
+      <div class="layout-settings">
+        <label>Columns: <input type="number" id="grid-columns" min="1"></label>
+        <label>Rows: <input type="number" id="grid-rows" min="1"></label>
       </div>
     </div>
     <div id="appearance-tab" class="tab-content hidden">

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -8,14 +8,19 @@ body {
 
 #widget-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  grid-auto-rows: minmax(100px, auto);
+  grid-template-columns: repeat(var(--cols, 4), 1fr);
+  grid-template-rows: repeat(var(--rows, 4), minmax(100px, 1fr));
   gap: 1rem;
   width: 100%;
   height: 100%;
   padding: 1rem;
   box-sizing: border-box;
-  place-items: center;
+}
+
+#widget-grid.jiggle-mode {
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 0.2) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.2) 1px, transparent 1px);
+  background-size: calc(100% / var(--cols, 4)) calc(100% / var(--rows, 4));
 }
 
 .widget {
@@ -63,6 +68,53 @@ body {
 
 #widgets-button:hover {
   background: rgba(255, 255, 255, 0.2);
+}
+
+#edit-button {
+  position: fixed;
+  bottom: 10px;
+  right: 110px;
+  font-size: 1.5rem;
+  padding: 0.4rem;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  backdrop-filter: blur(4px);
+  transition: background 0.3s;
+}
+
+#edit-button:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.jiggle-mode .widget {
+  position: relative;
+  resize: both;
+  overflow: auto;
+}
+
+.widget-action {
+  position: absolute;
+  top: 4px;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.widget-remove {
+  right: 4px;
+}
+
+.widget-settings {
+  right: 28px;
 }
 
 #settings-panel {

--- a/extension/widgets.js
+++ b/extension/widgets.js
@@ -4,12 +4,22 @@ const widgetsButton = document.getElementById('widgets-button');
 const widgetsPanel = document.getElementById('widgets-panel');
 const closeWidgetsButton = document.getElementById('close-widgets');
 const widgetList = document.getElementById('widget-list');
+const editButton = document.getElementById('edit-button');
+let jiggleMode = false;
+let dragIndex = null;
 
 widgetsPanel.classList.add('hidden');
 
 widgetsButton.addEventListener('click', () => {
   widgetsPanel.classList.remove('hidden');
   widgetsButton.classList.add('hidden');
+});
+
+editButton.addEventListener('click', () => {
+  jiggleMode = !jiggleMode;
+  editButton.textContent = jiggleMode ? 'Done' : 'Edit';
+  widgetGrid.classList.toggle('jiggle-mode', jiggleMode);
+  renderWidgets();
 });
 
 closeWidgetsButton.addEventListener('click', (e) => {
@@ -28,18 +38,48 @@ function saveAndRender() {
 
 function renderWidgets() {
   widgetGrid.innerHTML = '';
-  (settings.widgets || []).forEach(widget => {
+  (settings.widgets || []).forEach((widget, index) => {
     if (widget.type === 'clock') {
-      renderClockWidget(widget);
+      renderClockWidget(widget, index);
     }
   });
 }
 
-function renderClockWidget(widget) {
+function renderClockWidget(widget, index) {
   const container = document.createElement('div');
   container.className = 'widget clock-widget';
+  container.style.gridColumn = `span ${widget.w || 1}`;
+  container.style.gridRow = `span ${widget.h || 1}`;
+  container.dataset.index = index;
+
   const span = document.createElement('span');
   container.appendChild(span);
+
+  if (jiggleMode) {
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'widget-action widget-remove';
+    removeBtn.innerHTML = '&times;';
+    removeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      settings.widgets.splice(index, 1);
+      saveAndRender();
+    });
+    const settingsBtn = document.createElement('button');
+    settingsBtn.className = 'widget-action widget-settings';
+    settingsBtn.innerHTML = '&#9881;';
+    settingsBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      openWidgetSettings(widget, index);
+    });
+    container.appendChild(removeBtn);
+    container.appendChild(settingsBtn);
+    container.draggable = true;
+    container.addEventListener('dragstart', handleDragStart);
+    container.addEventListener('dragover', handleDragOver);
+    container.addEventListener('drop', handleDrop);
+    container.addEventListener('mouseup', handleResizeEnd);
+  }
+
   widgetGrid.appendChild(container);
 
   function isDST(d) {
@@ -74,6 +114,8 @@ function renderClockWidget(widget) {
 function addClockWidget(options) {
   const widget = {
     type: 'clock',
+    w: 1,
+    h: 1,
     settings: {
       showSeconds: options.showSeconds,
       flashing: options.flashing,
@@ -86,20 +128,58 @@ function addClockWidget(options) {
   saveAndRender();
 }
 
-function openClockConfig() {
+function handleDragStart(e) {
+  dragIndex = +e.currentTarget.dataset.index;
+  e.dataTransfer.effectAllowed = 'move';
+  e.dataTransfer.setData('text/plain', '');
+}
+
+function handleDragOver(e) {
+  e.preventDefault();
+}
+
+function handleDrop(e) {
+  e.preventDefault();
+  const targetIndex = +e.currentTarget.dataset.index;
+  if (dragIndex === null || dragIndex === targetIndex) return;
+  const [moved] = settings.widgets.splice(dragIndex, 1);
+  settings.widgets.splice(targetIndex, 0, moved);
+  dragIndex = null;
+  saveAndRender();
+}
+
+function handleResizeEnd(e) {
+  if (!jiggleMode) return;
+  const el = e.currentTarget;
+  if (e.target !== el) return;
+  const index = +el.dataset.index;
+  const colSize = widgetGrid.clientWidth / settings.grid.columns;
+  const rowSize = widgetGrid.clientHeight / settings.grid.rows;
+  const newW = Math.max(1, Math.round(el.offsetWidth / colSize));
+  const newH = Math.max(1, Math.round(el.offsetHeight / rowSize));
+  settings.widgets[index].w = newW;
+  settings.widgets[index].h = newH;
+  el.style.width = '';
+  el.style.height = '';
+  saveSettings(settings);
+  renderWidgets();
+}
+
+function openClockConfig(existing, index) {
+  const isEdit = !!existing;
   widgetList.innerHTML = `
-    <h3>Clock Widget</h3>
-    <label><input type="checkbox" id="clock-show-seconds" checked> Show seconds</label><br>
-    <label><input type="checkbox" id="clock-flashing"> Flashing separator</label><br>
-    <label><input type="checkbox" id="clock-use-24h"> 24 hour time</label><br>
-    <label><input type="checkbox" id="clock-daylight" checked> Use daylight savings</label><br>
-    <label>Locale: <input type="text" id="clock-locale" placeholder="auto"></label><br>
+    <h3>${isEdit ? 'Edit Clock Widget' : 'Clock Widget'}</h3>
+    <label><input type="checkbox" id="clock-show-seconds" ${!existing || existing.settings.showSeconds ? 'checked' : ''}> Show seconds</label><br>
+    <label><input type="checkbox" id="clock-flashing" ${existing && existing.settings.flashing ? 'checked' : ''}> Flashing separator</label><br>
+    <label><input type="checkbox" id="clock-use-24h" ${existing && existing.settings.use24h ? 'checked' : ''}> 24 hour time</label><br>
+    <label><input type="checkbox" id="clock-daylight" ${!existing || existing.settings.daylightSavings ? 'checked' : ''}> Use daylight savings</label><br>
+    <label>Locale: <input type="text" id="clock-locale" placeholder="auto" value="${existing ? (existing.settings.locale === 'auto' ? '' : existing.settings.locale) : ''}"></label><br>
     <div class="widget-config-buttons">
-      <button id="clock-add">Add</button>
-      <button id="clock-cancel">Cancel</button>
+      <button id="clock-save">${isEdit ? 'Save' : 'Add'}</button>
+      <button id="clock-cancel">${isEdit ? 'Exit' : 'Cancel'}</button>
     </div>
   `;
-  document.getElementById('clock-add').addEventListener('click', () => {
+  document.getElementById('clock-save').addEventListener('click', () => {
     const options = {
       showSeconds: document.getElementById('clock-show-seconds').checked,
       flashing: document.getElementById('clock-flashing').checked,
@@ -107,20 +187,37 @@ function openClockConfig() {
       daylightSavings: document.getElementById('clock-daylight').checked,
       locale: document.getElementById('clock-locale').value.trim() || 'auto'
     };
-    addClockWidget(options);
+    if (isEdit) {
+      settings.widgets[index].settings = options;
+      saveAndRender();
+    } else {
+      addClockWidget(options);
+    }
     widgetsPanel.classList.add('hidden');
     widgetsButton.classList.remove('hidden');
     buildWidgetList();
   });
-  document.getElementById('clock-cancel').addEventListener('click', buildWidgetList);
+  document.getElementById('clock-cancel').addEventListener('click', () => {
+    widgetsPanel.classList.add('hidden');
+    widgetsButton.classList.remove('hidden');
+    buildWidgetList();
+  });
 }
 
 function buildWidgetList() {
   widgetList.innerHTML = '';
   const clockBtn = document.createElement('button');
   clockBtn.textContent = 'Clock';
-  clockBtn.addEventListener('click', openClockConfig);
+  clockBtn.addEventListener('click', () => openClockConfig());
   widgetList.appendChild(clockBtn);
+}
+
+function openWidgetSettings(widget, index) {
+  widgetsPanel.classList.remove('hidden');
+  widgetsButton.classList.add('hidden');
+  if (widget.type === 'clock') {
+    openClockConfig(widget, index);
+  }
 }
 
 buildWidgetList();


### PR DESCRIPTION
## Summary
- Add "Edit" button to toggle jiggle mode with removable, movable, resizable widgets and per-widget settings
- Show grid guidelines in jiggle mode and store widget dimensions to resize responsively
- Introduce layout controls for configurable grid columns and rows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68961a1d78ec8331ae28dffe964ea13f