### PR TITLE
Fix overlapping widget buttons and enable editing

### DIFF
--- a/extension/newtab.html
+++ b/extension/newtab.html
@@ -7,9 +7,11 @@
 </head>
 <body>
   <div id="widget-grid" class="widget-grid"></div>
-  <div id="settings-button">&#9881;</div>
-  <div id="widgets-button">Widgets</div>
-  <div id="edit-button">Edit</div>
+  <div id="action-buttons">
+    <div id="settings-button" class="action-button">&#9881;</div>
+    <div id="widgets-button" class="action-button">Widgets</div>
+    <div id="edit-button" class="action-button">Edit</div>
+  </div>
   <div id="settings-panel" class="hidden">
     <button id="close-settings" class="close-button">&times;</button>
     <div class="settings-tabs">

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -34,10 +34,16 @@ body {
   font-size: 4rem;
 }
 
-#settings-button {
+#action-buttons {
   position: fixed;
   bottom: 10px;
   right: 10px;
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 0.5rem;
+}
+
+.action-button {
   font-size: 1.5rem;
   padding: 0.4rem;
   cursor: pointer;
@@ -48,43 +54,7 @@ body {
   transition: background 0.3s;
 }
 
-#settings-button:hover {
-  background: rgba(255, 255, 255, 0.2);
-}
-
-#widgets-button {
-  position: fixed;
-  bottom: 10px;
-  right: 60px;
-  font-size: 1.5rem;
-  padding: 0.4rem;
-  cursor: pointer;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
-  backdrop-filter: blur(4px);
-  transition: background 0.3s;
-}
-
-#widgets-button:hover {
-  background: rgba(255, 255, 255, 0.2);
-}
-
-#edit-button {
-  position: fixed;
-  bottom: 10px;
-  right: 110px;
-  font-size: 1.5rem;
-  padding: 0.4rem;
-  cursor: pointer;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
-  backdrop-filter: blur(4px);
-  transition: background 0.3s;
-}
-
-#edit-button:hover {
+.action-button:hover {
   background: rgba(255, 255, 255, 0.2);
 }
 

--- a/extension/widgets.js
+++ b/extension/widgets.js
@@ -1,5 +1,4 @@
 // Widget management
-const widgetGrid = document.getElementById('widget-grid');
 const widgetsButton = document.getElementById('widgets-button');
 const widgetsPanel = document.getElementById('widgets-panel');
 const closeWidgetsButton = document.getElementById('close-widgets');


### PR DESCRIPTION
## Summary
- place edit and widgets controls in a shared action bar to prevent overlap
- remove duplicate widgetGrid declaration so widget/edit buttons work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68961d1eafa48331ab3fb840cbddfae7